### PR TITLE
Fix of possible bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ## Synopsis
 
-Scan.R searches all Stata (.dta), SAS (.sas7bdat), SPSS (.sav), and comma-separated values (.csv) files found in the specified diectory for variables that may contain personally identifiable information (PII) using strings that commonly appear as part of variable names or labels that contain PII. (Note: Scan.R does not search labels in .csv files.) Results are displayed to the screen and saved to a comma-separated values file in the current working directory containing the variables and data flagged as potential PII.
+Scan.R searches all Stata (.dta), SAS (.sas7bdat), SPSS (.sav), and comma-separated values (.csv) files found in the specified directory for variables that may contain personally identifiable information (PII) using strings that commonly appear as part of variable names or labels that contain PII. (Note: Scan.R does not search labels in .csv files.) Results are displayed to the screen and saved to a comma-separated values file in the current working directory containing the variables and data flagged as potential PII.
 
 ## Instructions
 
-To execute the script, type `Rscript scan.R --path=[Target]` into the commadn line, replacing [Target] with the folder containing the data to scan. An excel spreadsheet titled "PII_output" will be saved in the current working directory for your review.
+To execute the script, type `Rscript scan.R --path=[Target]` into the command line, replacing [Target] with the folder containing the data to scan. An excel spreadsheet titled "PII_output" will be saved in the current working directory for your review.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ scan.R searches variables and labels for the following strings:
  * lat
  * lc
  * location
- * log
+ * lon
  * mother
  * network
  * panchayat

--- a/scan.R
+++ b/scan.R
@@ -118,7 +118,7 @@ pii_strings_locations <-
     "address",
     "gps",
     "lat",
-    "log",
+    "lon",
     "coord",
     "location",
     "house",


### PR DESCRIPTION
I was looking through the code and saw the match string `log` next to `lat` and `location`. `log` should likely be `lon` to match "longitude".

Also fixed are two minor typos in the readme file. 